### PR TITLE
bypass nginx statig file cache problems

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -3,3 +3,7 @@ SATIS_BIN="/satisfy/vendor/bin/satis"
 SATIS_PUBLIC="/satisfy/web/"
 
 ${SATIS_BIN} -n build /app/config.json ${SATIS_PUBLIC}
+
+# bypass nginx statig file cache problems..
+cat "${SATIS_PUBLIC}packages.json" > "${SATIS_PUBLIC}packages.json.tmp";
+mv "${SATIS_PUBLIC}packages.json.tmp" "${SATIS_PUBLIC}packages.json";


### PR DESCRIPTION
at least in my situation, the file packages.json get updated, but nginx delivers the old content.
with this "hack" the problem is solved.
