### PR TITLE
File permissions on id_rsa

### DIFF
--- a/scripts/startup.sh
+++ b/scripts/startup.sh
@@ -47,6 +47,8 @@ done
 echo " >> Copying host ssh key from /var/tmp/id to /root/.ssh/id_rsa"
 cp /var/tmp/id /root/.ssh/id_rsa
 
+chmod 600 /root/.ssh/id_rsa
+
 echo " >> Building Satis for the first time"
 scripts/build.sh
 


### PR DESCRIPTION
Read-Permission for the public key file should be restricted for users other than yourself due to security issues.
Also the key will be ignored if it has the wrong permissions.

"It is recommended that your private key files are NOT accessible by others.
This private key will be ignored."

@see https://www.howtogeek.com/168119/fixing-warning-unprotected-private-key-file-on-linux/